### PR TITLE
Add appointments page and progress tracking for patients

### DIFF
--- a/app/(patient)/Appointments.tsx
+++ b/app/(patient)/Appointments.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+import { db, auth } from '../../firebase.config';
+import { collection, query, where, getDocs, doc, getDoc } from 'firebase/firestore';
+
+interface Appointment {
+  id: string;
+  date: string;
+  time: string;
+  lieu: string;
+  orthophonistId: string;
+  orthophonistName: string;
+}
+
+export default function Appointments() {
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+
+  useEffect(() => {
+    const fetchAppointments = async () => {
+      if (!auth.currentUser) return;
+      const q = query(
+        collection(db, 'rendezvous'),
+        where('patientId', '==', auth.currentUser.uid)
+      );
+      const snap = await getDocs(q);
+      const list: Appointment[] = [];
+      for (const s of snap.docs) {
+        const data = s.data();
+        const orthoSnap = await getDoc(doc(db, 'users', data.orthophonistId));
+        list.push({
+          id: s.id,
+          date: data.date,
+          time: data.time,
+          lieu: data.lieu,
+          orthophonistId: data.orthophonistId,
+          orthophonistName: orthoSnap.data()?.name || '',
+        });
+      }
+      list.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+      const today = new Date().setHours(0, 0, 0, 0);
+      setAppointments(list.filter((a) => new Date(a.date).getTime() >= today));
+    };
+    fetchAppointments();
+  }, []);
+
+  return (
+    <View className="flex-1 bg-secondary p-4">
+      <Text className="text-lg font-bold mb-4">Mes rendez-vous</Text>
+      <FlatList
+        data={appointments}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View className="p-3 bg-primary mb-2 rounded-xl">
+            <Text className="text-secondary">
+              {item.date} {item.time}
+            </Text>
+            <Text className="text-secondary">Lieu : {item.lieu}</Text>
+            <Text className="text-secondary">
+              Orthophoniste : {item.orthophonistName}
+            </Text>
+          </View>
+        )}
+        ListEmptyComponent={<Text>Aucun rendez-vous à venir</Text>}
+      />
+    </View>
+  );
+}

--- a/app/(patient)/Dashboard.tsx
+++ b/app/(patient)/Dashboard.tsx
@@ -1,29 +1,73 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, Switch } from 'react-native';
+import { Button } from 'react-native-paper';
+import { router } from 'expo-router';
 import { db, auth } from '../../firebase.config';
-import { doc, getDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+import dayjs from 'dayjs';
 
 export default function Dashboard() {
   const [programme, setProgramme] = useState<any>(null);
+  const [completedDays, setCompletedDays] = useState<{ [key: string]: boolean }>(
+    {}
+  );
 
   useEffect(() => {
     const fetchProgramme = async () => {
       const snap = await getDoc(doc(db, 'programmes', auth.currentUser?.uid || ''));
       setProgramme(snap.data());
+      if (snap.data()?.days) {
+        const init: { [key: string]: boolean } = {};
+        Object.keys(snap.data().days).forEach((d) => (init[d] = false));
+        setCompletedDays(init);
+      }
     };
     fetchProgramme();
   }, []);
+
+  const handleToggle = async (day: string, value: boolean) => {
+    const updated = { ...completedDays, [day]: value };
+    setCompletedDays(updated);
+    if (!programme) return;
+    const total = Object.keys(programme.days || {}).length;
+    const done = Object.values(updated).filter(Boolean).length;
+    const percentage = Math.round((done / total) * 100);
+    const today = dayjs().format('YYYY-MM-DD');
+    await setDoc(
+      doc(db, 'suivi', auth.currentUser?.uid || ''),
+      { [today]: percentage },
+      { merge: true }
+    );
+  };
 
   return (
     <View className="flex-1 bg-secondary p-4">
       <Text className="text-lg font-bold mb-4">Programme de la semaine</Text>
       {programme ? (
         Object.entries(programme.days || {}).map(([day, ex]) => (
-          <Text key={day}>{day} : {ex}</Text>
+          <View
+            key={day}
+            className="flex-row justify-between items-center mb-2"
+          >
+            <Text>{day} : {ex}</Text>
+            <Switch
+              value={completedDays[day]}
+              onValueChange={(v) => handleToggle(day, v)}
+              trackColor={{ true: '#1C3F39', false: '#767577' }}
+              thumbColor={completedDays[day] ? '#EEE7D3' : '#f4f3f4'}
+            />
+          </View>
         ))
       ) : (
         <Text>Aucun programme assigné</Text>
       )}
+      <Button
+        mode="contained"
+        style={{ backgroundColor: '#1C3F39', marginTop: 20 }}
+        onPress={() => router.push('/(patient)/Appointments')}
+      >
+        Mes rendez-vous
+      </Button>
     </View>
   );
 }

--- a/app/(patient)/_layout.tsx
+++ b/app/(patient)/_layout.tsx
@@ -5,6 +5,7 @@ export default function PatientLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="Dashboard" />
+      <Stack.Screen name="Appointments" />
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- track daily program completion with toggles on patient dashboard
- store completion rate in `suivi/{patientId}`
- add navigation button to new appointments screen
- implement appointments list page
- register Appointments page in patient stack

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d2d71c3c8320939445a3b0802585