### PR TITLE
Change Habit time to ISO string

### DIFF
--- a/app/(Screens)/CreateHabit.tsx
+++ b/app/(Screens)/CreateHabit.tsx
@@ -15,7 +15,7 @@ const CreateHabit = () => {
   const [isLoading, setIsLoading] = useState(false);
 
   const [habitName, setHabitName] = useState("");
-  const [habitTime, setHabitTime] = useState<number | null>(null);
+  const [habitTime, setHabitTime] = useState<string | null>(null);
   const [habitFrequency, setHabitFrequency] = useState("daily");
   const [habitUoM, setHabitUoM] = useState<string | null>(null);
   const [habitQuantity, setHabitQuantity] = useState<number | null>(null);
@@ -212,7 +212,7 @@ const CreateHabit = () => {
                 mode="time"
                 onChange={(_, date) => {
                   setTimePickerVisible(false);
-                  setHabitTime(date ? date.getTime() : null);
+                  setHabitTime(date ? date.toISOString().slice(0, 16) : null);
                 }}
                 value={habitTime ? new Date(habitTime) : new Date()}
               ></DateTimePicker>

--- a/app/(Screens)/EditHabitDetails.tsx
+++ b/app/(Screens)/EditHabitDetails.tsx
@@ -22,7 +22,7 @@ const EditHabitDetails = ({
   const [isLoading, setIsLoading] = useState(false);
 
   const [habitName, setHabitName] = useState(selectedHabit.name);
-  const [habitTime, setHabitTime] = useState<number | null>(selectedHabit.time);
+  const [habitTime, setHabitTime] = useState<string | null>(selectedHabit.time);
   const [habitFrequency, setHabitFrequency] = useState(selectedHabit.frequency);
   const [habitUoM, setHabitUoM] = useState<string | null>(selectedHabit.uom);
   const [habitQuantity, setHabitQuantity] = useState<number | null>(
@@ -291,7 +291,7 @@ const EditHabitDetails = ({
                 mode="time"
                 onChange={(_, date) => {
                   setTimePickerVisible(false);
-                  setHabitTime(date ? date.getTime() : null);
+                  setHabitTime(date ? date.toISOString().slice(0, 16) : null);
                 }}
                 value={habitTime ? new Date(habitTime) : new Date()}
               ></DateTimePicker>

--- a/app/interfaces/habits.ts
+++ b/app/interfaces/habits.ts
@@ -2,7 +2,10 @@ export interface Habit {
   id: string;
   frequency: string;
   name: string;
-  time: number; // TODO: convert to datetime string,
+  /**
+   * ISO datetime string for reminder time (e.g. 'YYYY-MM-DDTHH:mm')
+   */
+  time: string;
   uom: string;
   total_units: number;
   completed_units: number;


### PR DESCRIPTION
## Summary
- make `Habit.time` a string instead of number
- update CreateHabit and EditHabitDetails screens for ISO string times

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855e479b3c083208afabc4e0ccf80e1